### PR TITLE
Empty check for iterables

### DIFF
--- a/modules/quality-check/src/main/java/net/sf/qualitycheck/Check.java
+++ b/modules/quality-check/src/main/java/net/sf/qualitycheck/Check.java
@@ -1982,6 +1982,29 @@ public final class Check {
 	}
 
 	/**
+	 * Ensures that a passed iterable as a parameter of the calling method is not empty.
+	 * 
+	 * <p>
+	 * We recommend to use the overloaded method {@link Check#notEmpty(Iterable, String)} and pass as second argument
+	 * the name of the parameter to enhance the exception message.
+	 * 
+	 * @param iterable
+	 *            an iterable which should not be empty
+	 * @return the passed reference that is not empty
+	 * @throws IllegalNullArgumentException
+	 *             if the given argument {@code iterable} is {@code null}
+	 * @throws IllegalEmptyArgumentException
+	 *             if the given argument {@code iterable} is empty
+	 */
+	@ArgumentsChecked
+	@Throws({ IllegalNullArgumentException.class, IllegalEmptyArgumentException.class })
+	public static <T extends Iterable<?>> T notEmpty(@Nonnull final T iterable) {
+		notNull(iterable);
+		notEmpty(iterable, !iterable.iterator().hasNext(), EMPTY_ARGUMENT_NAME);
+		return iterable;
+	}
+
+	/**
 	 * Ensures that a passed map as a parameter of the calling method is not empty.
 	 * 
 	 * <p>
@@ -2127,6 +2150,37 @@ public final class Check {
 		notNull(collection, name);
 		notEmpty(collection, collection.isEmpty(), name);
 		return collection;
+	}
+
+	/**
+	 * Ensures that a passed iterable as a parameter of the calling method is not empty.
+	 * 
+	 * <p>
+	 * The following example describes how to use it.
+	 * 
+	 * <pre>
+	 * &#064;ArgumentsChecked
+	 * public setIterable(Iterable&lt;String&gt; iterable) {
+	 * 	this.iterable = Check.notEmpty(iterable, &quot;iterable&quot;);
+	 * }
+	 * </pre>
+	 * 
+	 * @param iterable
+	 *            an iterable which should not be empty
+	 * @param name
+	 *            name of object reference (in source code)
+	 * @return the passed reference that is not empty
+	 * @throws IllegalNullArgumentException
+	 *             if the given argument {@code iterable} is {@code null}
+	 * @throws IllegalEmptyArgumentException
+	 *             if the given argument {@code iterable} is empty
+	 */
+	@ArgumentsChecked
+	@Throws({ IllegalNullArgumentException.class, IllegalEmptyArgumentException.class })
+	public static <T extends Iterable<?>> T notEmpty(@Nonnull final T iterable, @Nullable final String name) {
+		notNull(iterable, name);
+		notEmpty(iterable, !iterable.iterator().hasNext(), name);
+		return iterable;
 	}
 
 	/**

--- a/modules/quality-check/src/test/java/net/sf/qualitycheck/CheckTest_notEmpty.java
+++ b/modules/quality-check/src/test/java/net/sf/qualitycheck/CheckTest_notEmpty.java
@@ -18,6 +18,8 @@ package net.sf.qualitycheck;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -58,6 +60,18 @@ public class CheckTest_notEmpty {
 	public void notEmpty_emptyCollection_withArgName_isInvalid() {
 		final Set<String> collection = new HashSet<String>();
 		Check.notEmpty(collection, "collection");
+	}
+
+	@Test(expected = IllegalEmptyArgumentException.class)
+	public void notEmpty_emptyIterable_isInvalid() {
+		final Iterable<String> iterable = new LinkedList<String>();
+		Check.notEmpty(iterable);
+	}
+
+	@Test(expected = IllegalEmptyArgumentException.class)
+	public void notEmpty_emptyIterable_withArgName_isInvalid() {
+		final Iterable<String> iterable = new LinkedList<String>();
+		Check.notEmpty(iterable, "iterable");
 	}
 
 	@Test(expected = IllegalEmptyArgumentException.class)
@@ -132,6 +146,22 @@ public class CheckTest_notEmpty {
 		collection.add("hmm, what a tasty ice cream");
 		final Set<String> nonEmptySet = Check.notEmpty(collection, "collection");
 		Assert.assertSame(collection, nonEmptySet);
+	}
+
+	@Test
+	public void notEmpty_filledIterable_isValid() {
+		final List<String> iterable = new LinkedList<String>();
+		iterable.add("hmm, what a tasty ice cream");
+		final Iterable<String> nonEmptySet = Check.notEmpty((Iterable<String>) iterable);
+		Assert.assertSame(iterable, nonEmptySet);
+	}
+
+	@Test
+	public void notEmpty_filledIterable_withArgName_isValid() {
+		final List<String> iterable = new LinkedList<String>();
+		iterable.add("hmm, what a tasty ice cream");
+		final Iterable<String> nonEmptySet = Check.notEmpty((Iterable<String>) iterable, "iterable");
+		Assert.assertSame(iterable, nonEmptySet);
 	}
 
 	@Test


### PR DESCRIPTION
**Problem Description**

I am not able to check whether an iterable is empty. I like to use Iterable as an argument type if I have no requirements other than using this argument in a for loop.

**Solution**

Provide an `isEmpty` implementation for Iterable arguments.
